### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ profile
 *.moved-aside
 DerivedData
 .idea/
+.build
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:4.2
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.2
+
+import PackageDescription
+
+let package = Package(
+    name: "IGIdenticon",
+    platforms: [
+        .macOS(.v10_14),
+        .iOS(.v12)
+    ],
+    products: [
+        .library(name: "IGIdenticon", targets: [ "IGIdenticon" ]),
+    ],
+    targets: [
+        .target(name: "IGIdenticon", path: "Identicon")
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,14 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 
 let package = Package(
     name: "IGIdenticon",
     platforms: [
-        .macOS(.v10_14),
-        .iOS(.v12)
+        .macOS(.v10_10),
+        .iOS(.v8),
+        .watchOS(.v2),
+        .tvOS(.v9)
     ],
     products: [
         .library(name: "IGIdenticon", targets: [ "IGIdenticon" ]),

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ CocoaPods
 ```
 pod 'IGIdenticon'
 ```
+SwiftPM
+```swift
+  dependencies: [
+    .package(url: "https://github.com/seaburg/IGIdenticon.git",
+             from: "0.7.0")
+  ]
+```
+
 Usage
 -----
     imageView.image = Identicon().icon(from: "string", size: CGSize(width: 100, height: 100))


### PR DESCRIPTION
This adds support for SwiftPM, which allows Xcode to directly consume this package.

To make it work, you also need to tag a full semver version, e.g. `0.7.1`.